### PR TITLE
Feature: default license

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: insert-license
     name: Insert license in comments
     description: "Insert a short license disclaimer as a header comment in source files"
-    entry: insert-license
+    entry: insert-license --license-base64 Q29weXJpZ2h0IChjKSBRdWFudENvIHt5ZWFyX3N0YXJ0fS17eWVhcl9lbmR9ClNQRFgtTGljZW5zZS1JZGVudGlmaWVyOiBMaWNlbnNlUmVmLVF1YW50Q28K
     language: conda
     types: [text]

--- a/README.md
+++ b/README.md
@@ -12,18 +12,29 @@ repos:
       - id: insert-license
         types: [python]
         args:
-          - --license-base64
-          - "Q29weXJpZ2h0IChjKSBRdWFudENvIHt5ZWFyX3N0YXJ0fS17eWVhcl9lbmR9ClNQRFgtTGljZW5zZS1JZGVudGlmaWVyOiBMaWNlbnNlUmVmLVF1YW50Q28K"
           - --dynamic-years
           - --comment-style
           - "#"
 ```
 
+This hook uses our license header by default.
 
-The string contained in the example is a base64 encoded string of the license header we want to use:
+However, you can overwrite this default header by first creating your own base64 encoded string:
 ```
-$ echo "Copyright (c) QuantCo {year_start}-{year_end}\nSPDX-License-Identifier: LicenseRef-QuantCo" | base64
-Q29weXJpZ2h0IChjKSBRdWFudENvIHt5ZWFyX3N0YXJ0fS17eWVhcl9lbmR9ClNQRFgtTGljZW5zZS1JZGVudGlmaWVyOiBMaWNlbnNlUmVmLVF1YW50Q28K
+$ echo "Copyright (C) 2042, PearCorp, Inc.\nSPDX-License-Identifier: LicenseRef-PearCorp" | base64
+Q29weXJpZ2h0IChDKSAyMDQyLCBQZWFyQ29ycCwgSW5jLgpTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogTGljZW5zZVJlZi1QZWFyQ29ycAo=
+```
+And then supplying it to the hook:
+```
+[...]
+- id: insert-license
+        types: [python]
+        args:
+          - --license-base64
+          - "Q29weXJpZ2h0IChDKSAyMDQyLCBQZWFyQ29ycCwgSW5jLgpTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogTGljZW5zZVJlZi1QZWFyQ29ycAo="
+          - --dynamic-years
+          - --comment-style
+          - "#"
 ```
 
 Other comment styles:


### PR DESCRIPTION
* QuantCo license header is used by default without the need to specify a `--license-base64` argument in the `.pre-commit-config` file.
* A custom (repository-specific) license can still be provided by overwriting `--license-base64` in the `.pre-commit-config` file.